### PR TITLE
Updating to 2.16 api to support newer gerrit instances

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,12 +6,12 @@
 
     <groupId>org.beanbag</groupId>
     <artifactId>gerrit-reviewboard-plugin</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>
         <Gerrit-ApiType>plugin</Gerrit-ApiType>
-        <Gerrit-ApiVersion>2.13</Gerrit-ApiVersion>
+        <Gerrit-ApiVersion>2.16</Gerrit-ApiVersion>
     </properties>
 
     <build>
@@ -62,7 +62,7 @@
     <repositories>
         <repository>
             <id>maven.org</id>
-            <url>http://repo1.maven.org/maven2</url>
+            <url>https://repo1.maven.org/maven2</url>
         </repository>
     </repositories>
 </project>

--- a/src/main/java/org/reviewboard/rbgerrit/BlobResource.java
+++ b/src/main/java/org/reviewboard/rbgerrit/BlobResource.java
@@ -1,7 +1,7 @@
 package org.reviewboard.rbgerrit;
 
 import com.google.gerrit.extensions.restapi.*;
-import com.google.gerrit.server.project.ProjectControl;
+import com.google.gerrit.reviewdb.client.Project.NameKey;
 import com.google.gerrit.server.project.ProjectResource;
 import com.google.inject.TypeLiteral;
 import org.eclipse.jgit.lib.ObjectId;
@@ -39,12 +39,20 @@ public class BlobResource implements RestResource {
         this.objectId = objectId;
     }
 
+//    /**
+//     * Return the project's access control management.
+//     * @return The project's access control management.
+//     */
+//    public ProjectControl getProjectControl() {
+//        return projectResource.getControl();
+//    }
+
     /**
      * Return the project's access control management.
      * @return The project's access control management.
      */
-    public ProjectControl getProjectControl() {
-        return projectResource.getControl();
+    public NameKey getProjectNameKey() {
+        return projectResource.getProjectState().getNameKey();
     }
 
     /**

--- a/src/main/java/org/reviewboard/rbgerrit/BlobsCollection.java
+++ b/src/main/java/org/reviewboard/rbgerrit/BlobsCollection.java
@@ -53,7 +53,7 @@ public class BlobsCollection implements ChildCollection<ProjectResource, BlobRes
      */
     @Override
     public BlobResource parse(final ProjectResource parentResource, final IdString id) throws RestApiException {
-        final Project.NameKey projectName = parentResource.getControl().getProject().getNameKey();
+        final Project.NameKey projectName = parentResource.getProjectState().getNameKey();;
 
         try (final Repository repository = repoManager.openRepository(projectName)) {
             final ObjectId objId = repository.resolve(String.format("%s^{blob}", id.get()));

--- a/src/main/java/org/reviewboard/rbgerrit/CommitListResource.java
+++ b/src/main/java/org/reviewboard/rbgerrit/CommitListResource.java
@@ -18,17 +18,17 @@ import org.eclipse.jgit.revwalk.RevWalk;
 import org.eclipse.jgit.revwalk.filter.AndRevFilter;
 import org.eclipse.jgit.revwalk.filter.MaxCountRevFilter;
 import org.eclipse.jgit.revwalk.filter.RevFilter;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import org.joda.time.format.DateTimeFormatter;
-import org.joda.time.format.ISODateTimeFormat;
 import org.kohsuke.args4j.Option;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Date;
 import java.util.List;
 
 
@@ -85,7 +85,7 @@ public class CommitListResource implements RestReadView<ProjectResource> {
      */
     @Override
     public Response<Collection<CommitInfo>> apply(final ProjectResource parentResource) throws RestApiException {
-        final Project.NameKey projectName = parentResource.getControl().getProject().getNameKey();
+        final Project.NameKey projectName = parentResource.getNameKey();
 
         try (final Repository repository = repoManager.openRepository(projectName)) {
             final ObjectId startId = repository.resolve(String.format("%s^{commit}", start));
@@ -110,7 +110,7 @@ public class CommitListResource implements RestReadView<ProjectResource> {
      * Information about a single commit.
      */
     public static class CommitInfo {
-        private static final DateTimeFormatter formatter = ISODateTimeFormat.dateTimeNoMillis();
+        private static final DateTimeFormatter formatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
         public final String message;
         public final String revision;
         public final String author;
@@ -125,7 +125,8 @@ public class CommitListResource implements RestReadView<ProjectResource> {
             assert commit.getParentCount() == 1;
 
             final PersonIdent ident = commit.getAuthorIdent();
-            time = new DateTime(ident.getWhen(), DateTimeZone.forTimeZone(ident.getTimeZone())).toString(formatter);
+            ZonedDateTime zdt =  ZonedDateTime.ofInstant(ident.getWhen().toInstant(),ident.getTimeZone().toZoneId());
+            time = formatter.format(zdt);
             message = commit.getFullMessage();
             revision = commit.getId().getName();
             author = ident.getName();

--- a/src/main/java/org/reviewboard/rbgerrit/DiffResource.java
+++ b/src/main/java/org/reviewboard/rbgerrit/DiffResource.java
@@ -44,7 +44,7 @@ public class DiffResource implements RestReadView<CommitResource> {
      */
     @Override
     public BinaryResult apply(final CommitResource parentResource) throws RestApiException {
-        final Project.NameKey projectName = parentResource.getProject().getProject().getNameKey();
+        final Project.NameKey projectName = parentResource.getProjectState().getProject().getNameKey();
         final RevCommit commit = parentResource.getCommit();
         final int parentCount = commit.getParentCount();
 

--- a/src/main/java/org/reviewboard/rbgerrit/GetBlobContent.java
+++ b/src/main/java/org/reviewboard/rbgerrit/GetBlobContent.java
@@ -52,7 +52,7 @@ public class GetBlobContent implements RestReadView<BlobResource> {
      */
     @Override
     public BinaryResult apply(final BlobResource parentResource) throws RestApiException {
-        final Project.NameKey projectName = parentResource.getProjectControl().getProject().getNameKey();
+        final Project.NameKey projectName = parentResource.getProjectNameKey();
         try (final Repository repository = repoManager.openRepository(projectName)) {
             final ObjectLoader loader = repository.open(parentResource.getObjectId(), OBJ_BLOB);
             BinaryResult result;


### PR DESCRIPTION
Gerrit from 2.16 onwards stopped providing joda time as a dependency
updated CommitListResource to use Java 8 Time api

Projectresource no longer provides getControl() method NameKey provided off getProjectState

Bumped Version number to 1.0.1-Snapshot